### PR TITLE
Feat: Sorting repos by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The availabe variables are:
          - `name` - name of the repository
          - `html_url` - Github url
          - `description` - repository description
+         - `owner_login` - the repository owner login
 
 Similar projects
 ---

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Contents
 ---
 
 ## C
-   - [PikaPython](https://api.github.com/repos/pikasTech/PikaPython): An ultra-lightweight Python interpreter that runs with only 4KB of RAM, zero dependencies. It is ready to use out of the box without any configuration required and easy to extend with C. Similar project: MicroPython, JerryScript.
+   - [pikasTech/PikaPython](https://api.github.com/repos/pikasTech/PikaPython) - An ultra-lightweight Python interpreter that runs with only 4KB of RAM, zero dependencies. It is ready to use out of the box without any configuration required and easy to extend with C. Similar project: MicroPython, JerryScript.
 ## C#
-   - [kiota](https://api.github.com/repos/microsoft/kiota): OpenAPI based HTTP Client code generator
+   - [microsoft/kiota](https://api.github.com/repos/microsoft/kiota) - OpenAPI based HTTP Client code generator
 ...
 
 ```

--- a/default.jingoo
+++ b/default.jingoo
@@ -21,7 +21,7 @@ Contents
 ## {{ item.language }}
 
 {%- for repo in item.starred %}
-   - [{{ repo.name }}]({{ repo.html_url }}): {{ repo.description }}
+   - [{{repo.owner_login}}/{{ repo.name }}]({{ repo.html_url }}): {{ repo.description }}
 {%- endfor %}
 
 {% endfor %}

--- a/default.jingoo
+++ b/default.jingoo
@@ -21,7 +21,7 @@ Contents
 ## {{ item.language }}
 
 {%- for repo in item.starred %}
-   - [{{repo.owner_login}}/{{ repo.name }}]({{ repo.html_url }}): {{ repo.description }}
+   - [{{repo.owner_login}}/{{ repo.name }}]({{ repo.html_url }}) - {{ repo.description }}
 {%- endfor %}
 
 {% endfor %}

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -1,9 +1,13 @@
+type owner = { login : string }
+[@@deriving show, yojson { strict = false; exn = true }]
+
 type starred = {
   name : string;
   description : string option;
   topics : string list;
   language : string option;
   html_url : string;
+  owner : owner;
 }
 [@@deriving show, yojson { strict = false; exn = true }]
 

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -12,6 +12,10 @@ type starred_response = starred list
 
 let from_string s = Yojson.Safe.from_string s |> starred_response_of_yojson_exn
 
+(** group_by_first will group starred items by its language, if present. 
+ * returns a assoc list of starred items. The list is sorted by language alphabetically. Each
+ * left value of a language (the list of starred) is also sorted alphabetically.
+ *)
 let group_by_first lst =
   let ht = Hashtbl.create 30 in
   List.iter
@@ -19,7 +23,11 @@ let group_by_first lst =
       let values = try Hashtbl.find ht key with Not_found -> [] in
       Hashtbl.replace ht key (value :: values))
     lst;
-  Hashtbl.fold (fun key values acc -> (key, List.rev values) :: acc) ht []
+  Hashtbl.fold
+    (fun lang repos acc ->
+      (* Sorts the language list while folding into the final assoc list*)
+      (lang, List.sort (fun e e2 -> compare e.name e2.name) repos) :: acc)
+    ht []
   |> List.sort (fun (c1, _) (c2, _) -> Stdlib.compare c1 c2)
 
 let by_language s =

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -1,9 +1,15 @@
+type owner = {
+  login: string;
+}
+[@@deriving show, yojson { strict = false; exn = true}]
+
 type starred = {
   name : string;
   description : string option;
   topics : string list;
   language : string option;
-  html_url : string
+  html_url : string;
+  owner: owner;
 }
 [@@deriving show, yojson { strict = false; exn = true }]
 

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -31,6 +31,7 @@ let print_content items template =
                            match i.description with
                            | Some d -> Jg_types.Tstr d
                            | None -> Jg_types.Tnull );
+                         ("owner_login", Jg_types.Tstr i.owner.login);
                        ])
                    items') );
           ])

--- a/test/test_starred_ml.ml
+++ b/test/test_starred_ml.ml
@@ -20,6 +20,7 @@ let test_group () =
       topics = [ "Flow" ];
       language = Some "Java";
       html_url = "example.com";
+      owner = { login = "auser" };
     }
   and sample_java_repo2 =
     {
@@ -28,6 +29,7 @@ let test_group () =
       topics = [ "Flow" ];
       language = Some "Java";
       html_url = "example.com";
+      owner = { login = "viola" };
     }
   and sample_ocaml_repo =
     {
@@ -36,6 +38,7 @@ let test_group () =
       topics = [ "Flow" ];
       language = Some "Ocaml";
       html_url = "example.com";
+      owner = { login = "bar" };
     }
   in
   Alcotest.(check starred_testable)

--- a/test/test_starred_ml.ml
+++ b/test/test_starred_ml.ml
@@ -15,6 +15,14 @@ let starred_testable = Alcotest.testable starred_pp ( = )
 let test_group () =
   let sample_java_repo =
     {
+      name = "Xample";
+      description = Some "Description";
+      topics = [ "Flow" ];
+      language = Some "Java";
+      html_url = "example.com";
+    }
+  and sample_java_repo2 =
+    {
       name = "Sample";
       description = Some "Description";
       topics = [ "Flow" ];
@@ -32,8 +40,11 @@ let test_group () =
   in
   Alcotest.(check starred_testable)
     "Repos are grouped by topic"
-    [ ("Java", [ sample_java_repo ]); ("Ocaml", [ sample_ocaml_repo ]) ]
-    (by_language [ sample_java_repo; sample_ocaml_repo ])
+    [
+      ("Java", [ sample_java_repo2; sample_java_repo ]);
+      ("Ocaml", [ sample_ocaml_repo ]);
+    ]
+    (by_language [ sample_java_repo; sample_ocaml_repo; sample_java_repo2 ])
 
 let option_pp ppf o =
   match o with Some l -> Fmt.pf ppf "%s" l | None -> Fmt.pf ppf "No next link"


### PR DESCRIPTION
## Sortring
This small change makes the output sort the repositories under each language. For some reason, the recently generated awesome got some random sorting. I didn't want to spend time investigating and just went for sorting straight away.

I may change it to employ Sets in the future, avoiding internal language list iteration.

## Owner's login
The `default.jingoo` now uses a newly added variable, `owner_login,` to better create the links to the starred repositories.