### PR TITLE
Fix build failure: remove macOS-only linker flag and unused slug depe…

### DIFF
--- a/dune
+++ b/dune
@@ -1,3 +1,0 @@
-(env
- (_
-  (link_flags (:standard -ccopt -Wl,-no_warn_duplicate_libraries))))

--- a/dune-project
+++ b/dune-project
@@ -48,7 +48,5 @@
    (>= 1.3))
   (cohttp-eio
    (>= 6.2.1))
-  (slug
-   (>= 1.0.1))
   ocaml
   dune))

--- a/starred_ml.opam
+++ b/starred_ml.opam
@@ -22,7 +22,6 @@ depends: [
   "eio_main" {>= "1.3"}
   "eio" {>= "1.3"}
   "cohttp-eio" {>= "6.2.1"}
-  "slug" {>= "1.0.1"}
   "ocaml"
   "dune" {>= "3.21"}
   "odoc" {with-doc}


### PR DESCRIPTION
…ndency

The root dune file added in PR #11 used -Wl,-no_warn_duplicate_libraries, a macOS-specific linker flag not recognized by GNU ld on Linux (ubuntu CI). This caused dune build to fail with a linker error on ubuntu-22.04.

Also removes the stale `slug` dependency from dune-project and starred_ml.opam since the code no longer uses it (removed in v0.0.7 but not cleaned up from deps).

https://claude.ai/code/session_01FMvB6gQZy7SaksbRDc9ETC